### PR TITLE
fix: add git username and email

### DIFF
--- a/.github/workflows/generate_types.yml
+++ b/.github/workflows/generate_types.yml
@@ -17,6 +17,8 @@ jobs:
         run: npx openapi-typescript https://gr.lnkshrt.xyz/openapi.json -o ./src/lib/api_schema.d.ts
       - name: Commit file
         run: |
+          git config --global user.name github-actions[bot]
+          git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
           git add src/lib/api_schema.d.ts
           git commit -m "chore: generate API types"
           git push


### PR DESCRIPTION
CI was erroring out as git did not have user details - this PR adds the user.name and user.email required.
See also: https://github.com/actions/checkout/issues/13#issuecomment-724415212